### PR TITLE
Fixing access issues with KMS and Cloudwatch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 GitHub: [StratusGrid/terraform-aws-transfer-server-custom-idp-user](https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp-user)
 
-This is a Terraform module to create users for the AWS SFTP service based on custom identity provider using AWS Secrets Manager. To create the server and the identity provider, use [this module](https://registry.terraform.io/modules/StratusGrid/transfer-server-custom-idp/aws/latest).
+This is a Terraform module to create users for the AWS SFTP service based on custom identity provider using AWS Secrets Manager. To create the server and the identity provider, use [this module](https://registry.terraform.io/modules/StratusGrid/transfer-server-custom-idp/aws/latest). 
 
 ## Example Usage:
 Create one user to login in the AWS Transfer server.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 GitHub: [StratusGrid/terraform-aws-transfer-server-custom-idp-user](https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp-user)
 
-This is a Terraform module to create users for the AWS SFTP service based on custom identity provider using AWS Secrets Manager. To create the server and the identity provider, use [this module](https://registry.terraform.io/modules/StratusGrid/transfer-server-custom-idp/aws/latest). 
+This is a Terraform module to create users for the AWS SFTP service based on custom identity provider using AWS Secrets Manager. To create the server and the identity provider, use [this module](https://registry.terraform.io/modules/StratusGrid/transfer-server-custom-idp/aws/latest).
 
 ## Example Usage:
 Create one user to login in the AWS Transfer server.
@@ -46,6 +46,7 @@ module "transfer-server-custom-idp-user" {
 | Name | Type |
 |------|------|
 | [aws_iam_role.sftp_transfer_server_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.sftp_lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sftp_transfer_server_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_kms_key.secrets_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_secretsmanager_secret.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
@@ -60,9 +61,10 @@ module "transfer-server-custom-idp-user" {
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | String to append to object names. This is optional, so start with dash if using | `string` | `""` | no |
 | <a name="input_read_only"></a> [read\_only](#input\_read\_only) | Define if the user is created with read-only privileges | `bool` | `false` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Transfer Server S3 bucket name | `string` | n/a | yes |
+| <a name="input_secret_access_lambda_role"></a> [secret\_access\_lambda\_role](#input\_secret\_access\_lambda\_role) | Name of the role used by the secret-accessing Lambda. Used to add additional permissions as needed. May cause KMS errors if omitted. | `string` | `""` | no |
 | <a name="input_secrets_prefix"></a> [secrets\_prefix](#input\_secrets\_prefix) | Prefix used to create AWS Secrets | `string` | `"SFTP"` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | SSH Key for transfer server user | `string` | `""` | no |
-| <a name="input_user_home"></a> [user\_home](#input\_user\_home) | HOME path for transfer server user. Mustn't start with / | `string` | `""` | no |
+| <a name="input_user_home"></a> [user\_home](#input\_user\_home) | HOME path for transfer server user. Mustn't start or end with / | `string` | `""` | no |
 | <a name="input_user_name"></a> [user\_name](#input\_user\_name) | User name for SFTP server | `string` | n/a | yes |
 
 ## Outputs

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role_policy" "sftp_lambda_role_policy" {
-  name = "KmsAccess"
+  name = "KmsAccess-${var.user_name}"
   role = var.secret_access_lambda_role
 
   policy = <<EOF

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role_policy" "sftp_lambda_role_policy" {
   name = "KmsAccess"
-  role = var.secret_access_lambda_role_arn
+  role = var.secret_access_lambda_role
 
   policy = <<EOF
 {

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role_policy" "sftp_lambda_role_policy" {
+  name = "KmsAccess"
+  role = var.secret_access_lambda_role_arn
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "kms:Decrypt"
+            ],
+            "Resource": "${aws_kms_key.secrets_encryption.arn}",
+            "Effect": "Allow"
+        }
+    ]
+}
+EOF
+}

--- a/inputs.tf
+++ b/inputs.tf
@@ -49,8 +49,8 @@ variable "read_only" {
   default     = false
 }
 
-variable "secret_access_lambda_role_arn" {
-  description = "ARN of the role used by the secret-accessing Lambda. Used to add additional permissions as needed. May cause KMS errors if omitted."
+variable "secret_access_lambda_role" {
+  description = "Name of the role used by the secret-accessing Lambda. Used to add additional permissions as needed. May cause KMS errors if omitted."
   type        = string
   default     = ""
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -9,7 +9,7 @@ variable "user_name" {
 }
 
 variable "user_home" {
-  description = "HOME path for transfer server user. Mustn't start with /"
+  description = "HOME path for transfer server user. Mustn't start or end with /"
   type        = string
   default     = ""
 }
@@ -47,4 +47,10 @@ variable "read_only" {
   description = "Define if the user is created with read-only privileges"
   type        = bool
   default     = false
+}
+
+variable "secret_access_lambda_role_arn" {
+  description = "ARN of the role used by the secret-accessing Lambda. Used to add additional permissions as needed. May cause KMS errors if omitted."
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
## Change description

The additional KMS key rotation added in the user module (https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp-user/blob/618da1e3dd42201c59262eede13aa2714ca34dc2/main.tf#L38) will cause errors in the Lambda. The key policy alone is insufficient for access.

I've added a policy to attach the needed KMS access to the specified role. The role name to attach it to comes from the `terraform-aws-transfer-server-custom-idp` module.

I also updated the `user_home` to make it clear that it should not have a final `/`, either (it will cause double-slash issues in the resulting templated iam policy document).

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
